### PR TITLE
Mention Kraken in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ powerfulseal autonomous --policy-file ./policy.yaml
 - https://www.infoq.com/news/2018/01/powerfulseal-chaos-kubernetes
 - [PowerfulSeal presentation at KubeCon 2017 Austin](https://youtu.be/00BMn0UjsG4)
 
+
+## Tools consuming PowerfulSeal
+
+- Chaos and resiliency testing tool for Kubernetes and OpenShift: https://github.com/openshift-scale/kraken
+
 ---
 
 ## Footnotes


### PR DESCRIPTION
This commit adds a pointer to Kraken - chaos and resiliency tool
which consumes PowerfulSeal under the hood and maintained by
OpenShift Performance and Scale Team. Thanks to the PowerfulSeal
community for the amazing tool.

Signed-Off-By: Naga Ravi Chaitanya Elluri <nelluri@redhat.com>