### PR TITLE
Fix stop host action

### DIFF
--- a/powerfulseal/policy/action_pods.py
+++ b/powerfulseal/policy/action_pods.py
@@ -183,6 +183,9 @@ class ActionPods(ActionNodesPods):
             if host is None:
                 self.logger.warning("Couldn't find host with IP %r", host_ip)
                 return False
+            # check that we're not self-destructing
+            if len(self.dont_self_destruct([host])) == 0:
+                continue
             self.logger.info("Action stop on host %r (pods %s)", host, pods)
             try:
                 self.inventory.driver.stop(host)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.1.1
+version = 3.1.2
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters


### PR DESCRIPTION
Currently, setting `POD_NAME` and `HOST_IP` to the correct values will prevent PowerfulSeal from killing its own pod and host.

Unfortunately, that was never added to the kill host feature of pod host, so PowerfulSeal was happily self-destructing when using that. This PR fixes that.