### PR TITLE
Add alertmanager action to provide ability to mute alerts during chaos engineering

### DIFF
--- a/powerfulseal/policy/action_alertmanager.py
+++ b/powerfulseal/policy/action_alertmanager.py
@@ -115,8 +115,9 @@ class ActionAlertManager(ActionAbstract):
 
 
     def mute(self, url, duration):
-        self.logger.info("Silencing alerts for alert manager %s", url)
-        startTime = datetime.now()
+        self.logger.info("Silencing alerts for alert manager %s...", url)
+        # the local OS time zone will be assumed and included after astimezone call
+        startTime = datetime.now().astimezone()
         endTime = startTime + timedelta(seconds=duration)
         payload = {
             'comment': 'silence all alerts',
@@ -150,6 +151,8 @@ class ActionAlertManager(ActionAbstract):
             )
             resp.raise_for_status()
             silenceId = resp.json()['silenceID']
+            self.logger.info("Silenced alerts from %s to %s",
+                startTime.isoformat(), endTime.isoformat())
         except:
             self.logger.exception("Exception while calling %s", url)
         return silenceId

--- a/powerfulseal/policy/action_alertmanager.py
+++ b/powerfulseal/policy/action_alertmanager.py
@@ -1,0 +1,154 @@
+
+# Copyright 2017 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This alert manager action uses https://github.com/prometheus/alertmanager#api v2
+
+from powerfulseal import makeLogger
+
+from ..metriccollectors.stdout_collector import StdoutCollector
+from .action_abstract import ActionAbstract
+from datetime import datetime, timedelta
+import requests
+
+# Action class to delete generated silences in ActionAlertManager
+class ActionUnmuteAlertManager():
+    def __init__(self, name, silence_id, alertmanager_url, proxies={}, logger=None):
+        self.name = name
+        self.logger = logger or makeLogger(__name__, name)
+        self.silence_id = silence_id
+        self.alertmanager_url = alertmanager_url
+        self.proxies = proxies
+
+    def execute(self):
+        url = self.alertmanager_url + '/silence/' + self.silence_id
+        self.logger.info("Unmuting alerts for alert manager %s", self.alertmanager_url)
+        success = False
+        try:
+            resp = requests.request(
+                method="DELETE",
+                url=url,
+                proxies=dict(
+                    http=self.proxies.get("http", ""),
+                    https=self.proxies.get("https", "")
+                ),
+                verify=False,
+            )
+            resp.raise_for_status()
+            success = True
+        except:
+            self.logger.exception("Exception while calling %s", url)
+        return success
+ 
+
+class ActionAlertManager(ActionAbstract):
+
+    def __init__(self, name, schema, logger=None, metric_collector=None):
+        self.name = name
+        self.schema = schema
+        self.logger = logger or makeLogger(__name__, name)
+        self.metric_collector = metric_collector or StdoutCollector()
+        self.targets = self.schema.get("targets", [])
+        self.proxies = self.schema.get("proxies", {})
+        self.silences = dict()
+        # build a url indexed map to store generated silences in mute action
+        for target in self.targets:
+            url = target.get("url", None)
+            if url is not None:
+                self.silences[url] = None
+        self.action_mapping = {
+            "mute": self.action_mute
+        }
+        self.cleanup_actions = []
+
+    def execute(self):
+        actions = self.schema.get("actions", [])
+        self.logger.info("executing alertmanager actions...")
+
+        success = True
+        for action in actions:
+            for key, method in self.action_mapping.items():
+                if key in action:
+                    params = action.get(key)
+                    ret = method(params)
+                    if not ret:
+                        success = False
+        return success
+
+    def action_mute(self, params):
+        success = True
+        # automute is True unless explicitly set to False
+        autoUnmute = params.get('autoUnmute', True) if type(params) is dict else True
+        for alert_manager in self.silences:
+            self.silences[alert_manager] = self.mute(alert_manager)
+            if self.silences[alert_manager] is not None:
+                if autoUnmute is True:
+                    # add unmute action for cleaning up when mute action generates silence
+                    # and `autoUnmute` is True
+                    self.cleanup_actions.append(
+                        ActionUnmuteAlertManager(
+                            name=self.name,
+                            silence_id=self.silences[alert_manager],
+                            alertmanager_url=alert_manager,
+                            proxies=self.proxies
+                    ))
+            elif success:
+                success = False
+        return success
+
+
+    def mute(self, url):
+        self.logger.info("Silencing alerts for alert manager %s", url)
+        startTime = datetime.now()
+        # mute all alerts for 15 mins (900 secs)
+        endTime = startTime + timedelta(seconds=900)
+        payload = {
+            'comment': 'silence all alerts',
+            'createdBy': 'powerfulseal',
+            'startsAt': startTime.isoformat(),
+            'endsAt': endTime.isoformat(),
+            'matchers': [
+                {
+                    'isRegex': True,
+                    'name': 'alertname',
+                    'value': '.+'
+                }
+            ]
+        }
+        url = url + '/silences'
+        silenceId = None
+        try:
+            resp = requests.request(
+                method="POST",
+                url=url,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "powefulseal"
+                },
+                proxies=dict(
+                    http=self.proxies.get("http", ""),
+                    https=self.proxies.get("https", "")
+                ),
+                json=payload,
+                verify=False,
+            )
+            resp.raise_for_status()
+            silenceId = resp.json()['silenceID']
+        except:
+            self.logger.exception("Exception while calling %s", url)
+        return silenceId
+
+    # required to finish cleaning up (removing generated silences)
+    def get_cleanup_actions(self):
+        return self.cleanup_actions

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -1127,6 +1127,12 @@ definitions:
         type: object
         additionalProperties: false
         properties:
+          duration:
+            type: integer
+            description: >
+              Number of seconds alerts are muted for
+            minimum: 60
+            maximum: 86400
           autoUnmute:
             type: boolean
             description:

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -130,6 +130,8 @@ definitions:
           - "$ref": "#/definitions/nodeAction"
           - "$ref": "#/definitions/waitAction"
           - "$ref": "#/definitions/cloneAction"
+          - "$ref": "#/definitions/alertManagerAction"
+
     required:
     - name
     - steps
@@ -472,6 +474,51 @@ definitions:
         - source
     required:
     - clone
+
+  alertManagerAction:
+    description: >
+      Allows to interact with alert managers such as muting all alerts
+    type: object
+    properties:
+      alertManagerAction:
+        type: object
+        targets:
+          type: array
+          items:
+            oneOf:
+            - "$ref": "#/definitions/targetURL"
+        actions:
+          type: array
+          description: >
+            An array of actions to be applied to each alert manager target.
+          items:
+            type: object
+            oneOf:
+            - "$ref": "#/definitions/actionMuteAlertManager"
+        retries:
+          type: object
+          description: >
+            An object of retry criteria to rerun set actions
+          oneOf:
+            - "$ref": "#/definitions/retriesCount"
+            - "$ref": "#/definitions/retriesTimeout"
+        proxies:
+          type: object
+          description: >
+            Specify the http and https proxies needed to reach alert manager targets
+          additionalProperties: false
+          properties:
+            http:
+              type: string
+              default: ""
+            https:
+              type: string
+              default: ""
+        required:
+          - targets
+          - actions
+    required:
+    - alertManagerAction
 
 
 ###################################################################################################
@@ -1067,6 +1114,28 @@ definitions:
     - environment
 
 ###################################################################################################
+# ALERT MANAGER
+###################################################################################################
+
+  actionMuteAlertManager:
+    type: object
+    description: >
+      mute all alerts of an alert manager
+    additionalProperties: false
+    properties:
+      mute:
+        type: object
+        additionalProperties: false
+        properties:
+          autoUnmute:
+            type: boolean
+            description:
+              When set to true, powerfulseal will unmute alerts during cleanup
+            default: true
+    required:
+    - mute
+
+###################################################################################################
 # MISC
 ###################################################################################################
 
@@ -1146,3 +1215,4 @@ definitions:
         - namespace
     required:
     - service
+

--- a/powerfulseal/policy/scenario.py
+++ b/powerfulseal/policy/scenario.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import time
-
 from powerfulseal import makeLogger
 
 from ..metriccollectors.stdout_collector import StdoutCollector
@@ -23,7 +22,7 @@ from .action_pods import ActionPods
 from .action_kubectl import ActionKubectl
 from .action_probe_http import ActionProbeHTTP
 from .action_clone import ActionClone
-
+from .action_alertmanager import ActionAlertManager
 
 class Scenario():
     """
@@ -47,6 +46,7 @@ class Scenario():
             probeHTTP=self.action_probe_http,
             wait=self.action_wait,
             clone=self.action_clone,
+            alertManagerAction=self.action_alertmanager
         )
         self.cleanup_list = []
 
@@ -178,3 +178,11 @@ class Scenario():
             k8s_inventory=self.k8s_inventory,
         )
         return self.execute_action(action)
+
+    def action_alertmanager(self, schema):
+        action = ActionAlertManager(
+            schema=schema,
+            name=self.name
+        )
+        return self.execute_action(action)
+

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -19,6 +19,7 @@ from powerfulseal.policy.action_probe_http import ActionProbeHTTP
 from powerfulseal.policy.action_nodes import ActionNodes
 from powerfulseal.policy.action_pods import ActionPods
 from powerfulseal.policy.action_nodes_pods import ActionNodesPods
+from powerfulseal.policy.action_alertmanager import ActionAlertManager, ActionUnmuteAlertManager
 from powerfulseal.execute import SSHExecutor
 
 
@@ -139,5 +140,23 @@ def action_probe_http():
             )
         ),
         k8s_inventory=k8s_inventory,
+        logger=logger,
+    )
+
+
+@pytest.fixture
+def action_alertmanager():
+    logger = MagicMock()
+    return ActionAlertManager(
+        name="test alert manager action",
+        schema=dict(
+            targets = [
+                dict(url="http://example.com")
+            ],
+            actions= [
+                dict(mute = dict())
+            ],
+            proxies=dict(http='http',https='https')
+        ),
         logger=logger,
     )

--- a/tests/policy/test_action_alertmanager.py
+++ b/tests/policy/test_action_alertmanager.py
@@ -1,0 +1,72 @@
+import pytest
+from mock import MagicMock, patch
+
+from tests.fixtures import action_alertmanager, ActionUnmuteAlertManager, ActionAlertManager
+
+# single target cases
+def test_happy_path(action_alertmanager):
+    mock_resp = 'silence_id'
+    action_alertmanager.mute = MagicMock(
+        return_value=mock_resp
+    )
+    action_alertmanager.execute()
+
+    # muting should store silence id
+    assert(action_alertmanager.silences == {
+        'http://example.com': 'silence_id'
+    })
+    assert(action_alertmanager.proxies == dict(http='http',https='https'))
+
+    # muting should push unmuting action for cleaning up
+    cleanup_action = action_alertmanager.cleanup_actions[0]
+    assert(type(cleanup_action) is ActionUnmuteAlertManager)
+    assert(cleanup_action.silence_id == 'silence_id')
+    assert(cleanup_action.alertmanager_url == 'http://example.com')
+    assert(cleanup_action.proxies == dict(http='http',https='https'))
+
+def test_no_proxy(action_alertmanager):
+    action_alertmanager.proxies = {}
+    action_alertmanager.mute = MagicMock()
+    action_alertmanager.execute()
+    assert(action_alertmanager.cleanup_actions[0].proxies == {})
+
+# autoUnmute is set to false
+def test_autounmute_disabled(action_alertmanager):
+    action_alertmanager.schema["actions"][0]["mute"] = {'autoUnmute': False}
+    action_alertmanager.mute = MagicMock()
+    action_alertmanager.execute()
+    # no clean up action when autoUnmute is false
+    assert(len(action_alertmanager.cleanup_actions) == 0)
+
+# what if 'mute' is None
+def test_mute_is_none(action_alertmanager):
+    action_alertmanager.schema["actions"][0]["mute"] = None
+    action_alertmanager.mute = MagicMock()
+    action_alertmanager.execute()
+
+# multiple targets cases
+@patch.object(ActionAlertManager, 'mute')
+def test_multiple_targets_happy_path(mute):
+    mute.side_effect = ['silence_1', 'silence_2']
+    logger = MagicMock()
+    action_alertmanager = ActionAlertManager(
+        name="test alert manager action",
+        schema=dict(
+            targets = [
+                dict(url="http://example1.com"),
+                dict(url="http://example2.com")
+            ],
+            actions= [
+                dict(mute = dict())
+            ],
+            proxies=dict(http='http',https='https')
+        ),
+        logger=logger,
+    )
+    action_alertmanager.execute()
+    assert(action_alertmanager.silences == {
+        'http://example1.com': 'silence_1',
+        'http://example2.com': 'silence_2'
+    })
+    cleanup_action = action_alertmanager.cleanup_actions
+    assert(len(cleanup_action) == 2)

--- a/tests/policy/test_action_alertmanager.py
+++ b/tests/policy/test_action_alertmanager.py
@@ -16,6 +16,8 @@ def test_happy_path(action_alertmanager):
         'http://example.com': 'silence_id'
     })
     assert(action_alertmanager.proxies == dict(http='http',https='https'))
+    # test default silence duration
+    action_alertmanager.mute.assert_called_once_with('http://example.com', 900)
 
     # muting should push unmuting action for cleaning up
     cleanup_action = action_alertmanager.cleanup_actions[0]
@@ -43,6 +45,15 @@ def test_mute_is_none(action_alertmanager):
     action_alertmanager.schema["actions"][0]["mute"] = None
     action_alertmanager.mute = MagicMock()
     action_alertmanager.execute()
+    # test default silence duration
+    action_alertmanager.mute.assert_called_once_with('http://example.com', 900)
+
+def test_duration_override(action_alertmanager):
+    action_alertmanager.schema["actions"][0]["mute"] = {'duration': 123}
+    action_alertmanager.mute = MagicMock()
+    action_alertmanager.execute()
+    # test default silence duration
+    action_alertmanager.mute.assert_called_once_with('http://example.com', 123)
 
 # multiple targets cases
 @patch.object(ActionAlertManager, 'mute')


### PR DESCRIPTION
- [x] alert managers can be config by giving its URLs e.g. (multiple alert managers are supported)
```
  steps:
  - alertManagerAction:
      targets:
        - url: http://<alert_manager_1_url>:9093/api/v2
        - url: http://<alert_manager_2_url>:9093/api/v2
      actions:
        - mute:
```
- [x] by default alerts are muted for 15 mins and will be unmuted afterwards, but if you do not want to unmute it, you can do 

```
      actions:
        - mute:
                autoUnmute:  false
```
- [x] additional fields include `proxies` which you can specify `http` and `https` proxies
- [x] unit tests are added