### PR TITLE
Allow a python dict for configuration

### DIFF
--- a/powerfulseal/k8s/k8s_client.py
+++ b/powerfulseal/k8s/k8s_client.py
@@ -28,8 +28,10 @@ class K8sClient():
     """
 
     def __init__(self, kube_config=None, logger=None):
-        if kube_config:
+        if isinstance(kube_config, str):
             kubernetes.config.load_kube_config(config_file=kube_config)
+        elif isinstance(kube_config, dict):
+            kubernetes.config.load_kube_config_from_dict(config_dict=kube_config)
         else:
             kubernetes.config.load_incluster_config()
         self.kube_config = kube_config

--- a/powerfulseal/policy/policy_runner.py
+++ b/powerfulseal/policy/policy_runner.py
@@ -34,8 +34,8 @@ class PolicyRunner():
         "scenarios": []
     }
 
-    def __init__(self, config_file, k8s_client, logger=None):
-        self.config_file = config_file
+    def __init__(self, policy_config, k8s_client, logger=None):
+        self.policy_config = policy_config
         self.k8s_client = k8s_client
         self.logger = logger or makeLogger(__name__)
 
@@ -43,10 +43,14 @@ class PolicyRunner():
         """
             Read configuration
         """
-        if self.config_file is None:
+        if self.policy_config is None:
             policy = copy.deepcopy(PolicyRunner.DEFAULT_POLICY)
+        elif isinstance(self.policy_config, str):
+            policy = PolicyRunner.load_file(self.policy_config)
+        elif isinstance(self.policy_config, dict):
+            policy = self.policy_config
         else:
-            policy = PolicyRunner.load_file(self.config_file)
+            policy = copy.deepcopy(PolicyRunner.DEFAULT_POLICY)
 
         # Load scenarios from K8S crd extending file scenarios
         scenarios = self.k8s_client.get_scenarios()

--- a/powerfulseal/policy/policy_runner.py
+++ b/powerfulseal/policy/policy_runner.py
@@ -43,13 +43,11 @@ class PolicyRunner():
         """
             Read configuration
         """
-        if self.policy_config is None:
-            policy = copy.deepcopy(PolicyRunner.DEFAULT_POLICY)
-        elif isinstance(self.policy_config, str):
+        if isinstance(self.policy_config, str):
             policy = PolicyRunner.load_file(self.policy_config)
         elif isinstance(self.policy_config, dict):
             policy = self.policy_config
-        else:
+        else: #  is None or unsupported
             policy = copy.deepcopy(PolicyRunner.DEFAULT_POLICY)
 
         # Load scenarios from K8S crd extending file scenarios


### PR DESCRIPTION
#335 This allows another python process to pass a config instead of having to write it to a file and asking powerfulseal to import it

