### PR TITLE
Support targeting only chaos pods

### DIFF
--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -448,6 +448,14 @@ definitions:
               The object to clone. It must exist on the cluster. Its specs will be used for the clone.
             oneOf:
             - "$ref": "#/definitions/matchPodDeploymentAndNamespace"
+          services:
+            type: array
+            description: >
+              Services to add the guaranteed label "chaos=true" to the selector
+            items:
+              type: object
+              oneOf:
+              - "$ref": "#/definitions/matchService"
           labels:
             type: array
             description: >


### PR DESCRIPTION
#336 With the addition of statefulset, routing traffic to affected pods can no longer be left to the loadbalancer. Here we add the guaranteed chaos label to an existing service.