### PR TITLE
Add simple sidecar option

### DIFF
--- a/powerfulseal/policy/action_clone.py
+++ b/powerfulseal/policy/action_clone.py
@@ -210,7 +210,7 @@ class ActionClone(ActionAbstract):
       )
     )
 
-    # add the toxiproxy side-car container
+    # add the delayed tc side-car container
     body.spec.template.spec.containers.append(
       kubernetes.client.V1Container(
         name="chaos-tc",

--- a/powerfulseal/policy/action_clone.py
+++ b/powerfulseal/policy/action_clone.py
@@ -189,12 +189,31 @@ class ActionClone(ActionAbstract):
     return True
 
   def mutate_traffic_control(self, body, spec):
-    """ Adds an init container with tc """
+    """ Adds an init container with tc setup """
     if body.spec.template.spec.init_containers is None:
       body.spec.template.spec.init_containers = []
+    setup_spec = spec.get("setup")
     body.spec.template.spec.init_containers.append(
       kubernetes.client.V1Container(
-        name="chaos"+str(1+len(body.spec.template.spec.init_containers)),
+        name="chaos-setup-"+str(1+len(body.spec.template.spec.init_containers)),
+        command=setup_spec.get("command", "/bin/sh"),
+        args=setup_spec.get("args", "tc show eth0 && tc qdisc add dev eth0 root handle 1: prio bands 2 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 && tc show eth0"),
+        image=setup_spec.get("image",spec.get("image")),
+        security_context=kubernetes.client.V1SecurityContext(
+          run_as_user=setup_spec.get("user",spec.get("user")),
+          capabilities=kubernetes.client.V1Capabilities(
+            add=[
+              "NET_ADMIN"
+            ]
+          )
+        )
+      )
+    )
+
+    # add the toxiproxy side-car container
+    body.spec.template.spec.containers.append(
+      kubernetes.client.V1Container(
+        name="chaos-tc",
         command=spec.get("command"),
         args=spec.get("args"),
         image=spec.get("image"),

--- a/powerfulseal/policy/ps-schema.yaml
+++ b/powerfulseal/policy/ps-schema.yaml
@@ -945,6 +945,36 @@ definitions:
         type: object
         additionalProperties: false
         properties:
+          setup:
+            type: object
+            command:
+              type: array
+              description: >
+                The command to execute as an array.
+                Entrypoint in docker.
+                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+              items:
+                type: string
+            args:
+              type: array
+              description: >
+                The arguments to execute as an array.
+                For example - "qdisc add dev eth0 root netem delay 200ms" to add 200ms delay on egress.
+                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+              items:
+                type: string
+            user:
+              type: number
+              minimum: 0
+              default: 0
+              description: >
+                The numeric UID of user to run as in the image.
+                Root (UID 0) is not the safest option.
+            image:
+              type: string
+              default: gaiadocker/iproute2:latest
+              description: >
+                The image to use.
           command:
             type: array
             description: >


### PR DESCRIPTION
#333 Similar to toxicproxy, we can add a sidecar container to run tc attacks. There's some finicky business with crafting the command so it doesn't keep restarting and failing
