### PR TITLE
Honor probeHTTP code field

### DIFF
--- a/powerfulseal/policy/action_probe_http.py
+++ b/powerfulseal/policy/action_probe_http.py
@@ -91,7 +91,8 @@ class ActionProbeHTTP(ActionAbstract):
                 ),
                 verify=verify,
             )
-            resp.raise_for_status()
+            if resp.status_code != code:
+                resp.raise_for_status()
             self.logger.info("Response: %s", resp.text)
             return True
         except:

--- a/powerfulseal/policy/action_probe_http.py
+++ b/powerfulseal/policy/action_probe_http.py
@@ -78,18 +78,22 @@ class ActionProbeHTTP(ActionAbstract):
             "Making a call: %s, %s, %r, %d, %d, %s, %s, %s",
             url, method, headers, timeout, code, body, proxy, verify
         )
-        resp = requests.request(
-            method.upper(),
-            url,
-            headers=headers,
-            timeout=timeout/1000,
-            data=body.encode("utf-8"),
-            proxies=dict(
-                http=proxy or "",
-                https=proxy or "",
-            ),
-            verify=verify,
-        )
+        try:
+            resp = requests.request(
+                method.upper(),
+                url,
+                headers=headers,
+                timeout=timeout/1000,
+                data=body.encode("utf-8"),
+                proxies=dict(
+                    http=proxy or "",
+                    https=proxy or "",
+                ),
+                verify=verify,
+            )
+        except:
+            self.logger.exception("Exception while calling %s", url)
+            return False
         if resp.status_code != code:
             self.logger.error(
                 "Expected response code %s, got %s instead. Response: %s",

--- a/powerfulseal/policy/action_probe_http.py
+++ b/powerfulseal/policy/action_probe_http.py
@@ -78,26 +78,28 @@ class ActionProbeHTTP(ActionAbstract):
             "Making a call: %s, %s, %r, %d, %d, %s, %s, %s",
             url, method, headers, timeout, code, body, proxy, verify
         )
-        try:
-            resp = requests.request(
-                method.upper(),
-                url,
-                headers=headers,
-                timeout=timeout/1000,
-                data=body.encode("utf-8"),
-                proxies=dict(
-                    http=proxy or "",
-                    https=proxy or "",
-                ),
-                verify=verify,
+        resp = requests.request(
+            method.upper(),
+            url,
+            headers=headers,
+            timeout=timeout/1000,
+            data=body.encode("utf-8"),
+            proxies=dict(
+                http=proxy or "",
+                https=proxy or "",
+            ),
+            verify=verify,
+        )
+        if resp.status_code != code:
+            self.logger.error(
+                "Expected response code %s, got %s instead. Response: %s",
+                code,
+                resp.status_code,
+                resp.text
             )
-            if resp.status_code != code:
-                resp.raise_for_status()
-            self.logger.info("Response: %s", resp.text)
-            return True
-        except:
-            self.logger.exception("Exception while calling %s", url)
-        return False
+            return False
+        self.logger.info("Response: %s", resp.text)
+        return True
 
     def execute(self):
         count = self.schema.get("count", 1)

--- a/tests/policy/test_action_probe_http.py
+++ b/tests/policy/test_action_probe_http.py
@@ -128,6 +128,26 @@ def test_get_url_code_does_not_match(action_probe_http):
     assert mock_request.call_count == 1
     assert execute_result is False
 
+def test_get_url_throws_exception(action_probe_http):
+    schema = dict(
+        target=dict(
+            url="http://10.10.10.10:80"
+        ),
+        headers=[dict(name="TEST", value="SOMETHING")],
+        method="POST",
+        body="SOMEBODY here!",
+        code=200,
+        timeout=2000,
+        insecure=True,
+    )
+    action_probe_http.schema = schema
+    mock_request = MagicMock(side_effect=Exception("something went wrong"))
+
+    with patch("requests.request", mock_request):
+        execute_result = action_probe_http.execute()
+
+    assert mock_request.call_count == 1
+    assert execute_result is False
 
 def test_get_url_proxy(action_probe_http):
     schema = dict(

--- a/tests/policy/test_action_probe_http.py
+++ b/tests/policy/test_action_probe_http.py
@@ -120,15 +120,14 @@ def test_get_url_code_does_not_match(action_probe_http):
     mock_response = MagicMock()
     mock_response.status_code = 404
     mock_response.text = "some response"
-    mock_response.raise_for_status = MagicMock(side_effect=Exception("404 Bad"))
     mock_request = MagicMock(return_value=mock_response)
 
     with patch("requests.request", mock_request):
         execute_result = action_probe_http.execute()
 
     assert mock_request.call_count == 1
-    assert mock_response.raise_for_status.call_count == 1
     assert execute_result is False
+
 
 def test_get_url_proxy(action_probe_http):
     schema = dict(

--- a/tests/policy/test_action_probe_http.py
+++ b/tests/policy/test_action_probe_http.py
@@ -80,6 +80,56 @@ def test_get_url_all_params(action_probe_http):
     assert args.args == ('POST', 'http://10.10.10.10:80/')
     assert args.kwargs == dict(headers={'TEST': 'SOMETHING'}, verify=False, timeout=2.0, data=b'SOMEBODY here!', proxies={'http': '', 'https': ''})
 
+def test_get_url_code_matches(action_probe_http):
+    schema = dict(
+        target=dict(
+            url="http://10.10.10.10:80"
+        ),
+        headers=[dict(name="TEST", value="SOMETHING")],
+        method="POST",
+        body="SOMEBODY here!",
+        code=404,
+        timeout=2000,
+        insecure=True,
+    )
+    action_probe_http.schema = schema
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "some response"
+    mock_request = MagicMock(return_value=mock_response)
+
+    with patch("requests.request", mock_request):
+        execute_result = action_probe_http.execute()
+
+    assert mock_request.call_count == 1
+    assert execute_result is True
+
+def test_get_url_code_does_not_match(action_probe_http):
+    schema = dict(
+        target=dict(
+            url="http://10.10.10.10:80"
+        ),
+        headers=[dict(name="TEST", value="SOMETHING")],
+        method="POST",
+        body="SOMEBODY here!",
+        code=200,
+        timeout=2000,
+        insecure=True,
+    )
+    action_probe_http.schema = schema
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "some response"
+    mock_response.raise_for_status = MagicMock(side_effect=Exception("404 Bad"))
+    mock_request = MagicMock(return_value=mock_response)
+
+    with patch("requests.request", mock_request):
+        execute_result = action_probe_http.execute()
+
+    assert mock_request.call_count == 1
+    assert mock_response.raise_for_status.call_count == 1
+    assert execute_result is False
+
 def test_get_url_proxy(action_probe_http):
     schema = dict(
         target=dict(


### PR DESCRIPTION
Closes #342.

This implements handling of the probeHTTP `code` field, which allows the user to specify the expected return code of an HTTP probe. Previously, setting this didn't work, unless the code returned was a non-4xx or 5xx code.