### PR TITLE
Api v1 broke 4.9 OpenShift

### DIFF
--- a/powerfulseal/k8s/k8s_client.py
+++ b/powerfulseal/k8s/k8s_client.py
@@ -31,11 +31,13 @@ class K8sClient():
         if kube_config:
             kubernetes.config.load_kube_config(config_file=kube_config)
         else:
+
             kubernetes.config.load_incluster_config()
+
         self.kube_config = kube_config
         self.client_corev1api = kubernetes.client.CoreV1Api()
         self.client_appsv1api = kubernetes.client.AppsV1Api()
-        self.client_extensionsApi = kubernetes.client.ApiextensionsV1beta1Api()
+        self.client_extensionsApi = kubernetes.client.ApiextensionsV1Api()
         self.client_customObjectsApi = kubernetes.client.CustomObjectsApi()
 
         self.logger = logger or makeLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = powerfulseal
-version = 3.2.0
+version = 3.3.0
 author = Mikolaj Pawlikowski
 author_email = mikolaj@pawlikowski.pl
 description = PowerfulSeal - a powerful testing tool for Kubernetes clusters
@@ -28,14 +28,14 @@ install_requires =
     termcolor>=1.1.0,<2
     openstacksdk>=0.10.0,<1
     spur>=0.3.20,<1
-    kubernetes==12.0.0a1
+    kubernetes==18.20.0
     PyYAML>=5.1.2,<6
     jsonschema>=3.0.2,<4
     boto3>=1.5.15,<2.0.0
     azure-common>=1.1.23,<2.0.0
     azure-identity>=1.5.0,<2.0.0
-    azure-mgmt-resource>=15.0.0      
-    azure-mgmt-network>=16.0.0      
+    azure-mgmt-resource>=15.0.0
+    azure-mgmt-network>=16.0.0
     azure-mgmt-compute>=17.0.0
     msrestazure>=0.6.4,<1.0.0
     future>=0.16.0,<1


### PR DESCRIPTION
The addition of [ApiextensionsV1beta1Api](https://github.com/powerfulseal/powerfulseal/commit/c51c567cc20f811bdfc45ac174feec0e9782f799)broke the autonomous pod scenarios for OpenShift 4.9. With setting the kuberenetes api to ApiextensionsV1Api it should work for all versions. 

Note: Updated the version of kubernetes as well. Definitely does not have to be added in this PR but think it should be updated to a more recent version soon 